### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # zsp
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/zapstore/zsp)
+
 A fast CLI tool for publishing Android apps to Nostr relays. Used by [Zapstore](https://zapstore.dev).
 
 ## Features


### PR DESCRIPTION
## Summary
- Adds a DeepWiki badge to the top of the README for easy access to AI-powered documentation at https://deepwiki.com/zapstore/zsp

🤖 Generated with [Claude Code](https://claude.com/claude-code)