### PR TITLE
Fixing Publishing Order

### DIFF
--- a/internal/workflow/upload.go
+++ b/internal/workflow/upload.go
@@ -69,6 +69,19 @@ type uploadItem struct {
 	apkPath    string
 }
 
+// PendingUploads holds blob uploads to be executed after Nostr events are published to relays.
+type PendingUploads struct {
+	client    *blossom.Client
+	items     []uploadItem
+	existsMap map[string]bool
+	opts      *cli.Options
+}
+
+// Execute performs the pending blob uploads to the Blossom server.
+func (p *PendingUploads) Execute(ctx context.Context) error {
+	return performUploads(ctx, p.client, p.items, p.existsMap, p.opts)
+}
+
 // PreDownloadImages downloads cfg.Icon and cfg.Images if they are remote URLs.
 func PreDownloadImages(ctx context.Context, cfg *config.Config, opts *cli.Options) (*PreDownloadedImages, error) {
 	result := &PreDownloadedImages{}
@@ -255,7 +268,7 @@ func resolveImageURLs(ctx context.Context, cfg *config.Config, blossomURL string
 }
 
 // UploadAndSignWithBatch handles uploads and signing when using a batch signer.
-func UploadAndSignWithBatch(ctx context.Context, params UploadParams) (*nostr.EventSet, error) {
+func UploadAndSignWithBatch(ctx context.Context, params UploadParams) (*nostr.EventSet, *PendingUploads, error) {
 	var uploads []uploadItem
 	var iconURL string
 	var imageURLs []string
@@ -284,7 +297,7 @@ func UploadAndSignWithBatch(ctx context.Context, params UploadParams) (*nostr.Ev
 		var err error
 		releaseNotes, err = source.FetchReleaseNotes(ctx, params.Cfg.ReleaseNotes, params.APKInfo.VersionName, params.Cfg.BaseDir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch release notes: %w", err)
+			return nil, nil, fmt.Errorf("failed to fetch release notes: %w", err)
 		}
 	}
 
@@ -338,50 +351,66 @@ func UploadAndSignWithBatch(ctx context.Context, params UploadParams) (*nostr.Ev
 		if signSpinner != nil {
 			signSpinner.StopWithError("Failed to sign events")
 		}
-		return nil, fmt.Errorf("failed to batch sign events: %w", err)
+		return nil, nil, fmt.Errorf("failed to batch sign events: %w", err)
 	}
 	if signSpinner != nil {
 		signSpinner.StopWithSuccess("Signed events")
 	}
 
-	// Perform uploads
-	if err := performUploads(ctx, params.Client, uploads, existsMap, params.Opts); err != nil {
-		return nil, err
+	pending := &PendingUploads{
+		client:    params.Client,
+		items:     uploads,
+		existsMap: existsMap,
+		opts:      params.Opts,
 	}
-
-	return events, nil
+	return events, pending, nil
 }
 
-// UploadWithIndividualSigning handles uploads with regular signers.
-func UploadWithIndividualSigning(ctx context.Context, params UploadParams) (iconURL string, imageURLs []string, err error) {
-	// Process icon
-	iconURL, err = uploadIcon(ctx, params)
-	if err != nil {
-		return "", nil, err
-	}
+// UploadWithIndividualSigning collects blobs for upload, signs their auth events one by one,
+// and returns the resolved URLs and a PendingUploads to be executed after relay publishing.
+func UploadWithIndividualSigning(ctx context.Context, params UploadParams) (iconURL string, imageURLs []string, pending *PendingUploads, err error) {
+	expiration := time.Now().Add(blossom.AuthExpiration)
 
-	// Process pre-downloaded images
-	if params.PreDownloaded != nil && len(params.PreDownloaded.Images) > 0 {
-		urls, err := uploadPreDownloadedImages(ctx, params)
-		if err != nil {
-			return "", nil, err
+	var uploads []uploadItem
+
+	// Collect icon
+	iconURL, iconUploads := collectIconUpload(ctx, params, expiration)
+	uploads = append(uploads, iconUploads...)
+
+	// Collect images
+	imgURLs, imgUploads := collectImageUploads(ctx, params, expiration)
+	imageURLs = append(imageURLs, imgURLs...)
+	uploads = append(uploads, imgUploads...)
+
+	// Add APK upload item
+	uploads = append(uploads, uploadItem{
+		isAPK:   true,
+		apkPath: params.APKPath,
+		hash:    params.APKInfo.SHA256,
+		authEvent: nostr.BuildBlossomAuthEvent(
+			params.APKInfo.SHA256, params.Pubkey, expiration,
+		),
+	})
+
+	// Sign each auth event individually
+	for _, u := range uploads {
+		signCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		signErr := params.Signer.Sign(signCtx, u.authEvent)
+		cancel()
+		if signErr != nil {
+			return "", nil, nil, fmt.Errorf("failed to sign blossom auth event: %w", signErr)
 		}
-		imageURLs = append(imageURLs, urls...)
 	}
 
-	// Process remaining config images
-	urls, err := uploadConfigImages(ctx, params)
-	if err != nil {
-		return "", nil, err
-	}
-	imageURLs = append(imageURLs, urls...)
+	// Pre-check existence for non-APK uploads
+	existsMap := checkUploadsExist(ctx, params.Client, uploads, params.Opts)
 
-	// Upload APK
-	if err := uploadAPK(ctx, params); err != nil {
-		return "", nil, err
-	}
-
-	return iconURL, imageURLs, nil
+	return iconURL, imageURLs, &PendingUploads{
+		client:    params.Client,
+		items:     uploads,
+		existsMap: existsMap,
+		opts:      params.Opts,
+	}, nil
 }
 
 // uploadIcon handles icon upload with various sources.

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -46,6 +46,7 @@ type Publisher struct {
 	releaseNotes             string
 	preDownloaded            *PreDownloadedImages
 	events                   *nostr.EventSet
+	pendingUploads           *PendingUploads
 	blossomURL               string
 	browserPort              int
 	existingReleaseTimestamp time.Time // created_at of existing 30063 on relay (for --overwrite-release)
@@ -145,7 +146,7 @@ func splitRelays(env string) []string {
 // Execute runs the complete publish workflow.
 func (p *Publisher) Execute(ctx context.Context) error {
 	// Determine total steps based on mode
-	totalSteps := 4
+	totalSteps := 5
 	if p.opts.Publish.Offline {
 		totalSteps = 2
 	}
@@ -176,9 +177,9 @@ func (p *Publisher) Execute(ctx context.Context) error {
 		return err
 	}
 
-	// Step 3: Sign & Upload (skip in offline mode)
+	// Step 3: Sign (skip in offline mode)
 	if steps != nil && !p.opts.Publish.Offline {
-		steps.StartStep("Sign & Upload")
+		steps.StartStep("Sign")
 	}
 	if err := p.signAndUpload(ctx); err != nil {
 		return err
@@ -198,7 +199,15 @@ func (p *Publisher) Execute(ctx context.Context) error {
 	if steps != nil {
 		steps.StartStep("Publish")
 	}
-	return p.publishToRelays(ctx)
+	if err := p.publishToRelays(ctx); err != nil {
+		return err
+	}
+
+	// Step 5: Upload blobs to Blossom
+	if steps != nil {
+		steps.StartStep("Upload")
+	}
+	return p.uploadBlobs(ctx)
 }
 
 // fetchAssets fetches and selects the APK to publish.
@@ -957,7 +966,7 @@ func (p *Publisher) uploadAndBuildEvents(ctx context.Context) error {
 
 	if isBatchSigner {
 		var err error
-		p.events, err = UploadAndSignWithBatch(ctx, UploadParams{
+		p.events, p.pendingUploads, err = UploadAndSignWithBatch(ctx, UploadParams{
 			Cfg:                 p.cfg,
 			APKInfo:             p.apkInfo,
 			APKPath:             p.apkPath,
@@ -981,12 +990,13 @@ func (p *Publisher) uploadAndBuildEvents(ctx context.Context) error {
 
 	// Regular signing mode
 	var err error
-	p.iconURL, p.imageURLs, err = UploadWithIndividualSigning(ctx, UploadParams{
+	p.iconURL, p.imageURLs, p.pendingUploads, err = UploadWithIndividualSigning(ctx, UploadParams{
 		Cfg:           p.cfg,
 		APKInfo:       p.apkInfo,
 		APKPath:       p.apkPath,
 		Client:        client,
 		Signer:        p.signer,
+		Pubkey:        p.signer.PublicKey(),
 		PreDownloaded: p.preDownloaded,
 		Opts:          p.opts,
 	})
@@ -1287,7 +1297,6 @@ func (p *Publisher) publishToRelays(ctx context.Context) error {
 	// Commit or clear cache
 	if allSuccess {
 		p.commitCache()
-		p.deleteCachedAPK()
 	} else {
 		p.clearCache()
 		if p.opts.Global.Verbose {
@@ -1323,6 +1332,18 @@ func (p *Publisher) publishToRelays(ctx context.Context) error {
 		return fmt.Errorf("failed to publish event(s) to any relay: %s", strings.Join(failedEventTypes, ", "))
 	}
 
+	return nil
+}
+
+// uploadBlobs executes pending Blossom uploads after events have been published to relays.
+func (p *Publisher) uploadBlobs(ctx context.Context) error {
+	if p.pendingUploads == nil {
+		return nil
+	}
+	if err := p.pendingUploads.Execute(ctx); err != nil {
+		return err
+	}
+	p.deleteCachedAPK()
 	return nil
 }
 


### PR DESCRIPTION
To have the repo verification work, zsp must first publish the app event, then all other events, and then trying to upload the blobs.

I tried to understand the zsp repo, but it's slop so I did what all the cool guys do nowadays, meaning I vibed a fix.

Accept at your own risk @franzaps :P 