### PR TITLE
Add has-new-release command

### DIFF
--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -60,7 +60,7 @@ type PublishOptions struct {
 
 // UtilsOptions holds flags specific to the utils subcommand.
 type UtilsOptions struct {
-	Operation string // "extract-apk"
+	Operation string // "extract-apk", "has-new-release"
 }
 
 // IdentityOptions holds flags specific to the identity subcommand.

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -42,17 +42,17 @@ type PublishOptions struct {
 	Channel string // Release channel: main (default), beta, nightly, dev
 
 	// Behavior flags
-	Offline             bool // Sign events without uploading/publishing (outputs to stdout)
-	Quiet               bool // No prompts, no spinners, auto-yes to all confirmations
-	SkipPreview         bool
-	OverwriteRelease    bool
-	IncludePreReleases  bool
-	SkipMetadata        bool
-	AppCreatedAtRelease bool // Use release timestamp for kind 32267 created_at
-	SkipAppEvent        bool // Publish only release events (kind 30063/3063), skip kind 32267
+	Offline                bool // Sign events without uploading/publishing (outputs to stdout)
+	Quiet                  bool // No prompts, no spinners, auto-yes to all confirmations
+	SkipPreview            bool
+	OverwriteRelease       bool
+	IncludePreReleases     bool
+	SkipMetadata           bool
+	AppCreatedAtRelease    bool // Use release timestamp for kind 32267 created_at
+	SkipAppEvent           bool // Publish only release events (kind 30063/3063), skip kind 32267
 	SkipCertificateLinking bool // Skip certificate-to-identity linking check
-	Wizard              bool
-	Check               bool // Verify config fetches arm64-v8a APK (exit 0=success)
+	Wizard                 bool
+	Check                  bool // Verify config fetches arm64-v8a APK (exit 0=success)
 
 	// Server options
 	Port int
@@ -60,7 +60,7 @@ type PublishOptions struct {
 
 // UtilsOptions holds flags specific to the utils subcommand.
 type UtilsOptions struct {
-	Operation string // "extract-apk" or "check-releases"
+	Operation string // "extract-apk"
 }
 
 // IdentityOptions holds flags specific to the identity subcommand.
@@ -286,7 +286,7 @@ func parseIdentityFlags(opts *Options, args []string) {
 }
 
 // parseUtilsArgs parses positional args for the utils subcommand.
-// The first positional arg is the operation: "extract-apk" or "check-releases".
+// The first positional arg is the operation: "extract-apk".
 func parseUtilsArgs(opts *Options, args []string) {
 	// Check for help
 	for _, a := range args {

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -353,12 +353,18 @@ func UtilsHelp() string {
 	b.WriteString(renderBold("OPERATIONS") + "\n")
 	writeFlag(&b, "extract-apk <file.apk>", "Extract APK metadata as JSON (stdout)")
 	b.WriteString("                            " + renderGreyDark("Also extracts the app icon to <name>_icon.png") + "\n")
+	writeFlag(&b, "has-new-release <config|url>", "Check if a new release exists since last publish")
+	b.WriteString("                             " + renderGreyDark("{\"has_new_release\":false} or {\"has_new_release\":true,\"version\":\"x.y.z\"}") + "\n")
+	b.WriteString("                             " + renderGreyDark("Local cache only — does not download the APK or query the relay") + "\n")
 	b.WriteString("\n")
 
 	b.WriteString(renderBold("EXAMPLES") + "\n\n")
 
 	b.WriteString(renderGreyDark("  # Extract metadata from an APK") + "\n")
 	b.WriteString("  " + renderAccent("zsp utils extract-apk myapp.apk") + "\n\n")
+
+	b.WriteString(renderGreyDark("  # Check if a new release is available (uses local cache)") + "\n")
+	b.WriteString("  " + renderAccent("zsp utils has-new-release zapstore.yaml") + "\n\n")
 
 	b.WriteString(renderBold("FLAGS") + "\n")
 	writeFlag(&b, "--json", "Machine-readable output (errors as JSON to stderr)")

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -13,9 +13,9 @@ import (
 
 // Greyscale palette only.
 var (
-	grey      = lipgloss.Color("245")
-	greyDark  = lipgloss.Color("242")
-	white     = lipgloss.Color("252")
+	grey       = lipgloss.Color("245")
+	greyDark   = lipgloss.Color("242")
+	white      = lipgloss.Color("252")
 	greyBright = lipgloss.Color("250")
 )
 
@@ -73,7 +73,7 @@ func RootHelp() string {
 	b.WriteString(renderBold("COMMANDS") + "\n")
 	b.WriteString("  " + renderAccent("publish") + "     " + renderWhite("Publish APK releases to Nostr relays") + "\n")
 	b.WriteString("  " + renderAccent("identity") + "    " + renderWhite("Manage cryptographic identity proofs (NIP-C1)") + "\n")
-	b.WriteString("  " + renderAccent("utils") + "       " + renderWhite("Operational utilities (extract-apk, check-releases)") + "\n\n")
+	b.WriteString("  " + renderAccent("utils") + "       " + renderWhite("Operational utilities (extract-apk)") + "\n\n")
 
 	b.WriteString(renderBold("EXAMPLES") + "\n")
 	writeExample(&b, "zsp publish --wizard", "Interactive wizard (recommended for first-time setup)")
@@ -353,8 +353,6 @@ func UtilsHelp() string {
 	b.WriteString(renderBold("OPERATIONS") + "\n")
 	writeFlag(&b, "extract-apk <file.apk>", "Extract APK metadata as JSON (stdout)")
 	b.WriteString("                            " + renderGreyDark("Also extracts the app icon to <name>_icon.png") + "\n")
-	writeFlag(&b, "check-releases <repo-url|config>", "Check for new upstream release without publishing")
-	b.WriteString("                                    " + renderGreyDark("{\"status\":\"new\",\"version\":\"x.y.z\"} or {\"status\":\"up_to_date\"}") + "\n")
 	b.WriteString("\n")
 
 	b.WriteString(renderBold("EXAMPLES") + "\n\n")
@@ -362,24 +360,14 @@ func UtilsHelp() string {
 	b.WriteString(renderGreyDark("  # Extract metadata from an APK") + "\n")
 	b.WriteString("  " + renderAccent("zsp utils extract-apk myapp.apk") + "\n\n")
 
-	b.WriteString(renderGreyDark("  # Check if a new release is available") + "\n")
-	b.WriteString("  " + renderAccent("zsp utils check-releases https://github.com/owner/repo") + "\n\n")
-
-	b.WriteString(renderGreyDark("  # Or use a config file") + "\n")
-	b.WriteString("  " + renderAccent("zsp utils check-releases zapstore.yaml") + "\n\n")
-
-	b.WriteString(renderGreyDark("  # Use in scripts to detect new versions (output is always JSON)") + "\n")
-	b.WriteString("  " + renderAccent("zsp utils check-releases https://github.com/owner/repo | jq -r .status") + "\n\n")
-
 	b.WriteString(renderBold("FLAGS") + "\n")
-	writeFlag(&b, "--pre-release", "Include pre-releases (check-releases)")
 	writeFlag(&b, "--json", "Machine-readable output (errors as JSON to stderr)")
 	writeFlag(&b, "--verbose", "Debug output")
 	writeFlag(&b, "--no-color", "Disable colored output")
 	b.WriteString("\n")
 
 	b.WriteString(renderBold("EXIT CODES") + "\n")
-	b.WriteString("  " + renderAccent("0") + "   Success (check-releases: JSON result on stdout)\n")
+	b.WriteString("  " + renderAccent("0") + "   Success\n")
 	b.WriteString("  " + renderAccent("1") + "   Error (source unreachable, no releases, invalid config)\n")
 
 	return b.String()

--- a/internal/source/fdroid.go
+++ b/internal/source/fdroid.go
@@ -21,8 +21,9 @@ import (
 // fdroidIndexCache stores the ETag and parsed package versions for a repo index.
 // Keyed on the index URL so all packages from the same repo share one cached file.
 type fdroidIndexCache struct {
-	ETag     string                          `json:"etag"`
-	Packages map[string][]fdroidPackageVersion `json:"packages"`
+	ETag                          string                            `json:"etag"`
+	Packages                      map[string][]fdroidPackageVersion `json:"packages"`
+	LatestPublishedReleaseVersion string                            `json:"latest_published_release_version,omitempty"`
 }
 
 // FDroid implements Source for F-Droid compatible repositories.
@@ -168,6 +169,9 @@ func (f *FDroid) FetchLatestRelease(ctx context.Context) (*Release, error) {
 	version, err := f.fetchLatestVersion(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if f.pending != nil && version != nil {
+		f.pending.LatestPublishedReleaseVersion = version.VersionName
 	}
 	return f.buildRelease(version), nil
 }

--- a/internal/source/fdroid.go
+++ b/internal/source/fdroid.go
@@ -105,6 +105,14 @@ func (f *FDroid) CommitCache() error {
 	return err
 }
 
+// GetPublishedVersion implements PublishedVersionReader.
+func (f *FDroid) GetPublishedVersion() string {
+	if cache := f.loadCache(); cache != nil {
+		return cache.LatestPublishedReleaseVersion
+	}
+	return ""
+}
+
 // SetSkipCache implements CacheSkipper.
 func (f *FDroid) SetSkipCache(v bool) { f.SkipCache = v }
 

--- a/internal/source/fdroid_test.go
+++ b/internal/source/fdroid_test.go
@@ -1,0 +1,60 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/zapstore/zsp/internal/config"
+)
+
+func TestFDroidCacheRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	f := &FDroid{
+		repoInfo: &config.FDroidRepoInfo{
+			IndexURL:  "https://f-droid.org/repo/index-v1.json",
+			PackageID: "de.danoeh.antennapod",
+		},
+		cacheDir: dir,
+	}
+
+	// No cache yet
+	if got := f.GetPublishedVersion(); got != "" {
+		t.Fatalf("expected empty version before any publish, got %q", got)
+	}
+
+	// Simulate FetchLatestRelease setting pending
+	f.pending = &fdroidIndexCache{
+		ETag:                          `"abc123"`,
+		LatestPublishedReleaseVersion: "3.4.2",
+	}
+
+	// CommitCache should write to disk and clear pending
+	if err := f.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error: %v", err)
+	}
+	if f.pending != nil {
+		t.Fatal("expected pending to be nil after CommitCache")
+	}
+
+	// GetPublishedVersion should read the written version
+	if got := f.GetPublishedVersion(); got != "3.4.2" {
+		t.Fatalf("GetPublishedVersion() = %q, want %q", got, "3.4.2")
+	}
+
+	// Commit with a new version (simulating a second publish)
+	f.pending = &fdroidIndexCache{
+		ETag:                          `"def456"`,
+		LatestPublishedReleaseVersion: "3.5.0",
+	}
+	if err := f.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error on second publish: %v", err)
+	}
+	if got := f.GetPublishedVersion(); got != "3.5.0" {
+		t.Fatalf("GetPublishedVersion() after update = %q, want %q", got, "3.5.0")
+	}
+
+	// CommitCache with no pending is a no-op
+	if err := f.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() with nil pending should not error: %v", err)
+	}
+}

--- a/internal/source/gitea.go
+++ b/internal/source/gitea.go
@@ -15,6 +15,11 @@ import (
 	"github.com/zapstore/zsp/internal/config"
 )
 
+// giteaCache stores the last successfully published release version.
+type giteaCache struct {
+	LatestPublishedReleaseVersion string `json:"latest_published_release_version,omitempty"`
+}
+
 // Gitea implements Source for Gitea/Forgejo/Codeberg releases.
 // This covers any Gitea-compatible forge (Gitea, Forgejo, Codeberg, etc.)
 type Gitea struct {
@@ -24,6 +29,8 @@ type Gitea struct {
 	repo               string
 	token              string
 	client             *http.Client
+	cacheDir           string
+	pendingVersion     string
 	IncludePreReleases bool // Set to true to include pre-releases (--pre-release)
 	SkipDownloadCache  bool // Set to true to skip saving APKs to download cache
 }
@@ -41,14 +48,68 @@ func NewGitea(cfg *config.Config) (*Gitea, error) {
 		return nil, fmt.Errorf("invalid Gitea repo path: %s", repoPath)
 	}
 
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = os.TempDir()
+	}
+	cacheDir = filepath.Join(cacheDir, "zsp", "gitea")
+
 	return &Gitea{
-		cfg:     cfg,
-		baseURL: baseURL,
-		owner:   parts[0],
-		repo:    parts[1],
-		token:   os.Getenv("GITEA_TOKEN"),
-		client:  newSecureHTTPClient(30 * time.Second),
+		cfg:      cfg,
+		baseURL:  baseURL,
+		owner:    parts[0],
+		repo:     parts[1],
+		token:    os.Getenv("GITEA_TOKEN"),
+		client:   newSecureHTTPClient(30 * time.Second),
+		cacheDir: cacheDir,
 	}, nil
+}
+
+func (g *Gitea) cacheFilePath() string {
+	return filepath.Join(g.cacheDir, fmt.Sprintf("%s_%s.json", g.owner, g.repo))
+}
+
+func (g *Gitea) loadCache() *giteaCache {
+	data, err := os.ReadFile(g.cacheFilePath())
+	if err != nil {
+		return nil
+	}
+	var cache giteaCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil
+	}
+	return &cache
+}
+
+func (g *Gitea) saveCache(cache *giteaCache) error {
+	if err := os.MkdirAll(g.cacheDir, 0755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(g.cacheFilePath(), data, 0644)
+}
+
+// CommitCache implements CacheCommitter.
+func (g *Gitea) CommitCache() error {
+	if g.pendingVersion == "" {
+		return nil
+	}
+	err := g.saveCache(&giteaCache{LatestPublishedReleaseVersion: g.pendingVersion})
+	if err == nil {
+		g.pendingVersion = ""
+	}
+	return err
+}
+
+// GetPublishedVersion returns the last successfully published release version.
+func (g *Gitea) GetPublishedVersion() string {
+	if cache := g.loadCache(); cache != nil {
+		return cache.LatestPublishedReleaseVersion
+	}
+	return ""
 }
 
 // Type returns the source type.
@@ -137,6 +198,7 @@ func (g *Gitea) fetchLatestFromList(ctx context.Context) (*Release, error) {
 		}
 		release := g.convertRelease(&r)
 		if HasValidAPKs(release.Assets) {
+			g.pendingVersion = release.Version
 			return release, nil
 		}
 	}
@@ -304,4 +366,3 @@ func (g *Gitea) matchesReleaseFilter(tagName string) bool {
 	}
 	return matched
 }
-

--- a/internal/source/gitea_test.go
+++ b/internal/source/gitea_test.go
@@ -1,0 +1,53 @@
+package source
+
+import (
+	"testing"
+)
+
+func TestGiteaCacheRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	g := &Gitea{
+		owner:    "Freeyourgadget",
+		repo:     "Gadgetbridge",
+		cacheDir: dir,
+	}
+
+	// No cache yet
+	if got := g.GetPublishedVersion(); got != "" {
+		t.Fatalf("expected empty version before any publish, got %q", got)
+	}
+
+	// Simulate FetchLatestRelease setting pendingVersion
+	g.pendingVersion = "0.79.0"
+
+	// CommitCache should write to disk and clear pendingVersion
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error: %v", err)
+	}
+	if g.pendingVersion != "" {
+		t.Fatal("expected pendingVersion to be empty after CommitCache")
+	}
+
+	// GetPublishedVersion should read the written version
+	if got := g.GetPublishedVersion(); got != "0.79.0" {
+		t.Fatalf("GetPublishedVersion() = %q, want %q", got, "0.79.0")
+	}
+
+	// Commit with a new version
+	g.pendingVersion = "0.80.0"
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error on second publish: %v", err)
+	}
+	if got := g.GetPublishedVersion(); got != "0.80.0" {
+		t.Fatalf("GetPublishedVersion() after update = %q, want %q", got, "0.80.0")
+	}
+
+	// CommitCache with empty pendingVersion is a no-op
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() with empty pendingVersion should not error: %v", err)
+	}
+	if got := g.GetPublishedVersion(); got != "0.80.0" {
+		t.Fatalf("GetPublishedVersion() after no-op CommitCache = %q, want %q", got, "0.80.0")
+	}
+}

--- a/internal/source/github.go
+++ b/internal/source/github.go
@@ -20,25 +20,27 @@ var ErrNotModified = fmt.Errorf("release not modified")
 
 // releaseCache stores ETag and release data for conditional requests.
 type releaseCache struct {
-	ETag    string         `json:"etag"`
-	Release *githubRelease `json:"release"`
+	ETag                          string         `json:"etag"`
+	Release                       *githubRelease `json:"release"`
+	LatestPublishedReleaseVersion string         `json:"latest_published_release_version,omitempty"`
 }
 
 // pendingCache stores cache data that hasn't been committed yet.
 // It's only saved to disk after successful publishing via CommitCache().
 type pendingCache struct {
-	ETag    string
-	Release *githubRelease
+	ETag                          string
+	Release                       *githubRelease
+	LatestPublishedReleaseVersion string
 }
 
 // GitHub implements Source for GitHub releases.
 type GitHub struct {
-	cfg       *config.Config
-	owner     string
-	repo      string
-	token     string
-	client    *http.Client
-	cacheDir  string
+	cfg                *config.Config
+	owner              string
+	repo               string
+	token              string
+	client             *http.Client
+	cacheDir           string
 	SkipCache          bool // Set to true to bypass ETag cache (--overwrite-release)
 	IncludePreReleases bool // Set to true to include pre-releases (--pre-release)
 	SkipDownloadCache  bool // Set to true to skip saving APKs to download cache
@@ -103,13 +105,14 @@ func (g *GitHub) loadCache() *releaseCache {
 }
 
 // saveCache writes the release data and ETag to disk.
-func (g *GitHub) saveCache(etag string, release *githubRelease) error {
+func (g *GitHub) saveCache(etag string, release *githubRelease, version string) error {
 	if err := os.MkdirAll(g.cacheDir, 0755); err != nil {
 		return err
 	}
 	cache := releaseCache{
-		ETag:    etag,
-		Release: release,
+		ETag:                          etag,
+		Release:                       release,
+		LatestPublishedReleaseVersion: version,
 	}
 	data, err := json.Marshal(&cache)
 	if err != nil {
@@ -148,7 +151,7 @@ func (g *GitHub) CommitCache() error {
 	if g.pending == nil {
 		return nil // Nothing to commit
 	}
-	err := g.saveCache(g.pending.ETag, g.pending.Release)
+	err := g.saveCache(g.pending.ETag, g.pending.Release, g.pending.LatestPublishedReleaseVersion)
 	if err == nil {
 		g.pending = nil // Clear pending after successful commit
 	}
@@ -245,9 +248,9 @@ func (g *GitHub) FetchLatestRelease(ctx context.Context) (*Release, error) {
 	if !ghRelease.Draft && !(ghRelease.Prerelease && !g.IncludePreReleases) && g.matchesReleaseFilter(ghRelease.TagName) {
 		release := g.convertRelease(&ghRelease)
 		if HasValidAPKs(release.Assets) {
-			// Store ETag and release for later commit (after successful publish).
+			// Store ETag, release, and version for later commit (after successful publish).
 			if etag := resp.Header.Get("ETag"); etag != "" {
-				g.pending = &pendingCache{ETag: etag, Release: &ghRelease}
+				g.pending = &pendingCache{ETag: etag, Release: &ghRelease, LatestPublishedReleaseVersion: release.Version}
 			}
 			return release, nil
 		}

--- a/internal/source/github.go
+++ b/internal/source/github.go
@@ -145,6 +145,14 @@ func (g *GitHub) ClearCache() error {
 	return err
 }
 
+// GetPublishedVersion implements PublishedVersionReader.
+func (g *GitHub) GetPublishedVersion() string {
+	if cache := g.loadCache(); cache != nil {
+		return cache.LatestPublishedReleaseVersion
+	}
+	return ""
+}
+
 // CommitCache saves the pending cache to disk.
 // This should be called after successful publishing to persist the ETag.
 func (g *GitHub) CommitCache() error {

--- a/internal/source/github_test.go
+++ b/internal/source/github_test.go
@@ -6,6 +6,67 @@ import (
 	"github.com/zapstore/zsp/internal/config"
 )
 
+func TestGitHubCacheRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	g := &GitHub{
+		owner:    "owner",
+		repo:     "repo",
+		cacheDir: dir,
+	}
+
+	// No cache yet
+	if got := g.GetPublishedVersion(); got != "" {
+		t.Fatalf("expected empty version before any publish, got %q", got)
+	}
+
+	// Simulate FetchLatestRelease setting pending
+	g.pending = &pendingCache{
+		ETag:                          `"etag-v1"`,
+		Release:                       &githubRelease{TagName: "v1.2.3"},
+		LatestPublishedReleaseVersion: "1.2.3",
+	}
+
+	// CommitCache should write to disk and clear pending
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error: %v", err)
+	}
+	if g.pending != nil {
+		t.Fatal("expected pending to be nil after CommitCache")
+	}
+
+	// GetPublishedVersion should read the written version
+	if got := g.GetPublishedVersion(); got != "1.2.3" {
+		t.Fatalf("GetPublishedVersion() = %q, want %q", got, "1.2.3")
+	}
+
+	// Commit with a new version
+	g.pending = &pendingCache{
+		ETag:                          `"etag-v2"`,
+		Release:                       &githubRelease{TagName: "v2.0.0"},
+		LatestPublishedReleaseVersion: "2.0.0",
+	}
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error on second publish: %v", err)
+	}
+	if got := g.GetPublishedVersion(); got != "2.0.0" {
+		t.Fatalf("GetPublishedVersion() after update = %q, want %q", got, "2.0.0")
+	}
+
+	// ClearCache should delete the file
+	if err := g.ClearCache(); err != nil {
+		t.Fatalf("ClearCache() error: %v", err)
+	}
+	if got := g.GetPublishedVersion(); got != "" {
+		t.Fatalf("expected empty version after ClearCache, got %q", got)
+	}
+
+	// CommitCache with no pending is a no-op
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() with nil pending should not error: %v", err)
+	}
+}
+
 func TestGitHub_matchesReleaseFilter(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/source/gitlab.go
+++ b/internal/source/gitlab.go
@@ -19,6 +19,11 @@ import (
 // gitlabArchRegex extracts architecture from GitLab asset names like "APK (arm64-v8a)"
 var gitlabArchRegex = regexp.MustCompile(`\((arm64-v8a|armeabi-v7a|arm|x86_64|x86)\)`)
 
+// gitlabCache stores the last successfully published release version.
+type gitlabCache struct {
+	LatestPublishedReleaseVersion string `json:"latest_published_release_version,omitempty"`
+}
+
 // GitLab implements Source for GitLab releases.
 // Supports both gitlab.com and self-hosted GitLab instances.
 type GitLab struct {
@@ -26,6 +31,8 @@ type GitLab struct {
 	baseURL           string // e.g., "https://gitlab.com" or self-hosted URL
 	projectID         string // URL-encoded project path (e.g., "user%2Frepo")
 	client            *http.Client
+	cacheDir          string
+	pendingVersion    string
 	SkipDownloadCache bool // Set to true to skip saving APKs to download cache
 }
 
@@ -47,12 +54,68 @@ func NewGitLab(cfg *config.Config) (*GitLab, error) {
 	// URL-encode the project path for API calls
 	projectID := url.PathEscape(repoPath)
 
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = os.TempDir()
+	}
+	cacheDir = filepath.Join(cacheDir, "zsp", "gitlab")
+
 	return &GitLab{
 		cfg:       cfg,
 		baseURL:   baseURL,
 		projectID: projectID,
 		client:    newSecureHTTPClient(30 * time.Second),
+		cacheDir:  cacheDir,
 	}, nil
+}
+
+func (g *GitLab) cacheFilePath() string {
+	name, _ := url.PathUnescape(g.projectID)
+	name = strings.ReplaceAll(name, "/", "_")
+	return filepath.Join(g.cacheDir, name+".json")
+}
+
+func (g *GitLab) loadCache() *gitlabCache {
+	data, err := os.ReadFile(g.cacheFilePath())
+	if err != nil {
+		return nil
+	}
+	var cache gitlabCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil
+	}
+	return &cache
+}
+
+func (g *GitLab) saveCache(cache *gitlabCache) error {
+	if err := os.MkdirAll(g.cacheDir, 0755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(g.cacheFilePath(), data, 0644)
+}
+
+// CommitCache implements CacheCommitter.
+func (g *GitLab) CommitCache() error {
+	if g.pendingVersion == "" {
+		return nil
+	}
+	err := g.saveCache(&gitlabCache{LatestPublishedReleaseVersion: g.pendingVersion})
+	if err == nil {
+		g.pendingVersion = ""
+	}
+	return err
+}
+
+// GetPublishedVersion returns the last successfully published release version.
+func (g *GitLab) GetPublishedVersion() string {
+	if cache := g.loadCache(); cache != nil {
+		return cache.LatestPublishedReleaseVersion
+	}
+	return ""
 }
 
 // Type returns the source type.
@@ -126,6 +189,7 @@ func (g *GitLab) FetchLatestRelease(ctx context.Context) (*Release, error) {
 		}
 		release := g.convertRelease(&glRelease)
 		if HasValidAPKs(release.Assets) {
+			g.pendingVersion = release.Version
 			return release, nil
 		}
 	}

--- a/internal/source/gitlab_test.go
+++ b/internal/source/gitlab_test.go
@@ -1,0 +1,52 @@
+package source
+
+import (
+	"testing"
+)
+
+func TestGitLabCacheRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	g := &GitLab{
+		projectID: "AuroraOSS%2FAuroraStore",
+		cacheDir:  dir,
+	}
+
+	// No cache yet
+	if got := g.GetPublishedVersion(); got != "" {
+		t.Fatalf("expected empty version before any publish, got %q", got)
+	}
+
+	// Simulate FetchLatestRelease setting pendingVersion
+	g.pendingVersion = "4.3.2"
+
+	// CommitCache should write to disk and clear pendingVersion
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error: %v", err)
+	}
+	if g.pendingVersion != "" {
+		t.Fatal("expected pendingVersion to be empty after CommitCache")
+	}
+
+	// GetPublishedVersion should read the written version
+	if got := g.GetPublishedVersion(); got != "4.3.2" {
+		t.Fatalf("GetPublishedVersion() = %q, want %q", got, "4.3.2")
+	}
+
+	// Commit with a new version
+	g.pendingVersion = "4.4.0"
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error on second publish: %v", err)
+	}
+	if got := g.GetPublishedVersion(); got != "4.4.0" {
+		t.Fatalf("GetPublishedVersion() after update = %q, want %q", got, "4.4.0")
+	}
+
+	// CommitCache with empty pendingVersion is a no-op
+	if err := g.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() with empty pendingVersion should not error: %v", err)
+	}
+	if got := g.GetPublishedVersion(); got != "4.4.0" {
+		t.Fatalf("GetPublishedVersion() after no-op CommitCache = %q, want %q", got, "4.4.0")
+	}
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -297,6 +297,12 @@ type CacheCommitter interface {
 	CommitCache() error
 }
 
+// PublishedVersionReader is an optional interface for sources that can return
+// the last successfully published release version from their cache.
+type PublishedVersionReader interface {
+	GetPublishedVersion() string
+}
+
 // Downloader wraps an io.Reader to track download progress.
 type ProgressReader struct {
 	Reader     io.Reader

--- a/internal/source/web.go
+++ b/internal/source/web.go
@@ -44,6 +44,8 @@ type webCache struct {
 	ETag          string `json:"etag,omitempty"`
 	LastModified  string `json:"last_modified,omitempty"`
 	ContentLength int64  `json:"content_length,omitempty"` // Fallback when ETag/Last-Modified unavailable
+
+	LatestPublishedReleaseVersion string `json:"latest_published_release_version,omitempty"`
 }
 
 // NewWeb creates a new web scraping source.
@@ -322,6 +324,9 @@ func (w *Web) FetchLatestRelease(ctx context.Context) (*Release, error) {
 	}
 
 	// Store cache for later commit
+	if newCache != nil {
+		newCache.LatestPublishedReleaseVersion = version
+	}
 	w.pendingCache = newCache
 
 	// Create asset

--- a/internal/source/web.go
+++ b/internal/source/web.go
@@ -182,6 +182,14 @@ func (w *Web) ClearCache() error {
 	return err
 }
 
+// GetPublishedVersion implements PublishedVersionReader.
+func (w *Web) GetPublishedVersion() string {
+	if cache := w.loadCache(); cache != nil {
+		return cache.LatestPublishedReleaseVersion
+	}
+	return ""
+}
+
 // CommitCache saves the pending cache to disk.
 // This should be called after successful publishing to persist the cache.
 func (w *Web) CommitCache() error {

--- a/internal/source/web_test.go
+++ b/internal/source/web_test.go
@@ -1,0 +1,71 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/zapstore/zsp/internal/config"
+)
+
+func TestWebCacheRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	w := &Web{
+		cfg: &config.Config{
+			ReleaseSource: &config.ReleaseSource{
+				URL: "https://example.com/releases/app",
+			},
+		},
+		cacheDir: dir,
+	}
+
+	// No cache yet
+	if got := w.GetPublishedVersion(); got != "" {
+		t.Fatalf("expected empty version before any publish, got %q", got)
+	}
+
+	// Simulate FetchLatestRelease setting pendingCache (version extractor mode)
+	w.pendingCache = &webCache{
+		Version:                       "2.1.0",
+		AssetURL:                      "https://example.com/releases/app-2.1.0.apk",
+		LatestPublishedReleaseVersion: "2.1.0",
+	}
+
+	// CommitCache should write to disk and clear pendingCache
+	if err := w.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error: %v", err)
+	}
+	if w.pendingCache != nil {
+		t.Fatal("expected pendingCache to be nil after CommitCache")
+	}
+
+	// GetPublishedVersion should read the written version
+	if got := w.GetPublishedVersion(); got != "2.1.0" {
+		t.Fatalf("GetPublishedVersion() = %q, want %q", got, "2.1.0")
+	}
+
+	// Commit with a new version
+	w.pendingCache = &webCache{
+		Version:                       "2.2.0",
+		AssetURL:                      "https://example.com/releases/app-2.2.0.apk",
+		LatestPublishedReleaseVersion: "2.2.0",
+	}
+	if err := w.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() error on second publish: %v", err)
+	}
+	if got := w.GetPublishedVersion(); got != "2.2.0" {
+		t.Fatalf("GetPublishedVersion() after update = %q, want %q", got, "2.2.0")
+	}
+
+	// ClearCache should delete the file
+	if err := w.ClearCache(); err != nil {
+		t.Fatalf("ClearCache() error: %v", err)
+	}
+	if got := w.GetPublishedVersion(); got != "" {
+		t.Fatalf("expected empty version after ClearCache, got %q", got)
+	}
+
+	// CommitCache with nil pendingCache is a no-op
+	if err := w.CommitCache(); err != nil {
+		t.Fatalf("CommitCache() with nil pendingCache should not error: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -355,7 +355,13 @@ func hasNewRelease(ctx context.Context, arg string, opts *cli.Options) error {
 
 	release, err := src.FetchLatestRelease(ctx)
 	if err == source.ErrNotModified {
-		data, _ := json.Marshal(map[string]any{"has_new_release": false})
+		result := map[string]any{"has_new_release": false}
+		if reader, ok := src.(source.PublishedVersionReader); ok {
+			if v := reader.GetPublishedVersion(); v != "" {
+				result["release_version"] = v
+			}
+		}
+		data, _ := json.Marshal(result)
 		fmt.Println(string(data))
 		return nil
 	}
@@ -366,7 +372,7 @@ func hasNewRelease(ctx context.Context, arg string, opts *cli.Options) error {
 	// Compare with last published version
 	if reader, ok := src.(source.PublishedVersionReader); ok {
 		if cached := reader.GetPublishedVersion(); cached != "" && cached == release.Version {
-			data, _ := json.Marshal(map[string]any{"has_new_release": false})
+			data, _ := json.Marshal(map[string]any{"has_new_release": false, "release_version": release.Version})
 			fmt.Println(string(data))
 			return nil
 		}
@@ -374,7 +380,7 @@ func hasNewRelease(ctx context.Context, arg string, opts *cli.Options) error {
 
 	result := map[string]any{"has_new_release": true}
 	if release.Version != "" {
-		result["version"] = release.Version
+		result["release_version"] = release.Version
 	}
 	data, _ := json.Marshal(result)
 	fmt.Println(string(data))

--- a/main.go
+++ b/main.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"syscall"
 
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip19"
@@ -287,147 +287,11 @@ func runUtilsCommand(ctx context.Context, opts *cli.Options) int {
 		}
 		return 0
 
-	case "check-releases":
-		if len(opts.Args) == 0 {
-			if opts.Global.JSON {
-				ui.PrintJSONError(fmt.Errorf("check-releases requires a repository URL or config file as argument"))
-			} else {
-				fmt.Fprintln(os.Stderr, "Error: check-releases requires a repository URL as argument")
-				fmt.Fprintln(os.Stderr, "Usage: zsp utils check-releases <repo-url>")
-			}
-			return 1
-		}
-		if err := checkReleases(ctx, opts.Args[0], opts); err != nil {
-			if opts.Global.JSON {
-				ui.PrintJSONError(err)
-			} else {
-				fmt.Fprintf(os.Stderr, "Error: %s\n", ui.SanitizeErrorMessage(err))
-			}
-			return 1
-		}
-		return 0
-
 	default:
 		help.HandleHelp(cli.CommandUtils, nil)
 		return 0
 	}
 }
-
-// checkReleases checks for a new upstream release by downloading and parsing the APK.
-// Accepts a repository URL (e.g. https://github.com/owner/repo) or a config file path.
-// Outputs "NEW <version>" or "UP_TO_DATE" to stdout; exits 1 on source errors.
-func checkReleases(ctx context.Context, arg string, opts *cli.Options) error {
-	var cfg *config.Config
-
-	// Detect whether arg is a config file (YAML) or a URL.
-	lower := strings.ToLower(arg)
-	isConfigFile := strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml")
-	if !isConfigFile {
-		// Also treat it as a config file if it exists on disk and is not a URL.
-		if !strings.Contains(arg, "://") && !strings.Contains(arg, ".") {
-			isConfigFile = false
-		} else if _, err := os.Stat(arg); err == nil && !strings.HasPrefix(arg, "http") {
-			isConfigFile = true
-		}
-	}
-
-	if isConfigFile {
-		var err error
-		cfg, err = config.Load(arg)
-		if err != nil {
-			return fmt.Errorf("failed to load config: %w", err)
-		}
-		if err := cfg.Validate(); err != nil {
-			return fmt.Errorf("invalid config: %w", err)
-		}
-	} else {
-		repoURL := normalizeRepoURL(arg)
-		if err := config.ValidateURL(repoURL); err != nil {
-			return fmt.Errorf("invalid URL: %w", err)
-		}
-		cfg = &config.Config{Repository: repoURL}
-	}
-
-	src, err := source.NewWithOptions(cfg, source.Options{
-		BaseDir:            cfg.BaseDir,
-		SkipDownloadCache:  true,
-		IncludePreReleases: opts.Publish.IncludePreReleases,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create source: %w", err)
-	}
-
-	release, err := src.FetchLatestRelease(ctx)
-	if err == source.ErrNotModified {
-		// ETag 304 — nothing changed since last check
-		if cacheCommitter, ok := src.(source.CacheCommitter); ok {
-			_ = cacheCommitter.CommitCache()
-		}
-		data, _ := json.Marshal(map[string]string{"status": "up_to_date"})
-		fmt.Println(string(data))
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to fetch release: %w", err)
-	}
-
-	// Commit ETag cache after successful fetch
-	defer func() {
-		if cacheCommitter, ok := src.(source.CacheCommitter); ok {
-			_ = cacheCommitter.CommitCache()
-		}
-	}()
-
-	version := release.Version
-	if version == "" {
-		return fmt.Errorf("could not determine version from release (no version tag)")
-	}
-
-	// Select best APK asset
-	apkAssets := picker.FilterAPKs(release.Assets)
-	if len(apkAssets) == 0 {
-		return fmt.Errorf("no APK files found in release")
-	}
-
-	var selectedAsset *source.Asset
-	if len(apkAssets) == 1 {
-		selectedAsset = apkAssets[0]
-	} else {
-		ranked := picker.DefaultModel.RankAssets(apkAssets)
-		selectedAsset = ranked[0].Asset
-	}
-
-	// Download the APK (uses the shared download cache) and parse it for the real package ID.
-	apkPath, err := src.Download(ctx, selectedAsset, "", nil)
-	if err != nil {
-		return fmt.Errorf("failed to download APK: %w", err)
-	}
-
-	apkInfo, err := apk.Parse(apkPath)
-	if err != nil {
-		return fmt.Errorf("failed to parse APK: %w", err)
-	}
-
-	// Use the version from the APK if the release didn't carry one.
-	if version == "" {
-		version = apkInfo.VersionName
-	}
-
-	// Check relay for an existing asset with this package ID + version.
-	relaysEnv := config.GetEnv("RELAY_URLS")
-	publisher := nostrpkg.NewPublisherFromEnv(relaysEnv)
-	existingAsset, relayErr := publisher.CheckExistingAssetAny(ctx, apkInfo.PackageID, version)
-	if relayErr == nil && existingAsset != nil {
-		data, _ := json.Marshal(map[string]string{"status": "up_to_date"})
-		fmt.Println(string(data))
-		return nil
-	}
-
-	data, _ := json.Marshal(map[string]string{"status": "new", "version": version})
-	fmt.Println(string(data))
-	return nil
-}
-
 
 // runPublish executes the publish workflow.
 func runPublish(ctx context.Context, opts *cli.Options, cfg *config.Config) error {
@@ -484,7 +348,7 @@ func loadConfig(opts *cli.PublishOptions, args []string) (*config.Config, error)
 
 	// No config file — use stdin only if data is actually piped in.
 	stat, _ := os.Stdin.Stat()
-	if (stat.Mode()&os.ModeCharDevice) == 0 {
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		if r, ok := peekStdin(); ok {
 			return config.Parse(r)
 		}

--- a/main.go
+++ b/main.go
@@ -287,10 +287,98 @@ func runUtilsCommand(ctx context.Context, opts *cli.Options) int {
 		}
 		return 0
 
+	case "has-new-release":
+		if len(opts.Args) == 0 {
+			if opts.Global.JSON {
+				ui.PrintJSONError(fmt.Errorf("has-new-release requires a repository URL or config file as argument"))
+			} else {
+				fmt.Fprintln(os.Stderr, "Error: has-new-release requires a config file or URL as argument")
+				fmt.Fprintln(os.Stderr, "Usage: zsp utils has-new-release <config.yaml|repo-url>")
+			}
+			return 1
+		}
+		if err := hasNewRelease(ctx, opts.Args[0], opts); err != nil {
+			if opts.Global.JSON {
+				ui.PrintJSONError(err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", ui.SanitizeErrorMessage(err))
+			}
+			return 1
+		}
+		return 0
+
 	default:
 		help.HandleHelp(cli.CommandUtils, nil)
 		return 0
 	}
+}
+
+// hasNewRelease checks whether there is a new release since the last successful publish.
+// It is a read-only, local-cache-based check: it uses ETag and the stored
+// latest_published_release_version. It does NOT download the APK or query the relay.
+func hasNewRelease(ctx context.Context, arg string, opts *cli.Options) error {
+	var cfg *config.Config
+
+	lower := strings.ToLower(arg)
+	isConfigFile := strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml")
+	if !isConfigFile {
+		if _, err := os.Stat(arg); err == nil && !strings.HasPrefix(arg, "http") {
+			isConfigFile = true
+		}
+	}
+
+	if isConfigFile {
+		var err error
+		cfg, err = config.Load(arg)
+		if err != nil {
+			return fmt.Errorf("failed to load config: %w", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			return fmt.Errorf("invalid config: %w", err)
+		}
+	} else {
+		repoURL := normalizeRepoURL(arg)
+		if err := config.ValidateURL(repoURL); err != nil {
+			return fmt.Errorf("invalid URL: %w", err)
+		}
+		cfg = &config.Config{Repository: repoURL}
+	}
+
+	src, err := source.NewWithOptions(cfg, source.Options{
+		BaseDir:            cfg.BaseDir,
+		SkipDownloadCache:  true,
+		IncludePreReleases: opts.Publish.IncludePreReleases,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create source: %w", err)
+	}
+
+	release, err := src.FetchLatestRelease(ctx)
+	if err == source.ErrNotModified {
+		data, _ := json.Marshal(map[string]any{"has_new_release": false})
+		fmt.Println(string(data))
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to fetch release: %w", err)
+	}
+
+	// Compare with last published version
+	if reader, ok := src.(source.PublishedVersionReader); ok {
+		if cached := reader.GetPublishedVersion(); cached != "" && cached == release.Version {
+			data, _ := json.Marshal(map[string]any{"has_new_release": false})
+			fmt.Println(string(data))
+			return nil
+		}
+	}
+
+	result := map[string]any{"has_new_release": true}
+	if release.Version != "" {
+		result["version"] = release.Version
+	}
+	data, _ := json.Marshal(result)
+	fmt.Println(string(data))
+	return nil
 }
 
 // runPublish executes the publish workflow.


### PR DESCRIPTION
This PR removes the `utils check-releases` command, since it had several bugs:
- it would download the APK to extract the `app_id`, making this check as expensive as the full `zsp publish`
- despite the name suggesting the command is read-only, it would overwrite the source-specific cache with `CommitCache()`

The command has been replaced by `utils has-new-release`, which is a read-only, and doesn't download the APK.

I've also added unit tests for the cache logic of all sources, and performed a manual test to check the new command works as intended.